### PR TITLE
FIX : 에러 스택이 정상적으로 출력되지 않는 버그 수정

### DIFF
--- a/src/db/template/SqlTemplate.ts
+++ b/src/db/template/SqlTemplate.ts
@@ -14,6 +14,7 @@ class SqlTemplate {
 
       return rows;
     } catch (e) {
+      console.error(e);
       throw e;
     } finally {
       if (!conn && connection) connection.end();
@@ -33,6 +34,7 @@ class SqlTemplate {
 
       return false;
     } catch (e) {
+      console.error(e);
       throw e;
     } finally {
       if (!conn && connection) connection.end();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,10 +2,11 @@
   "compilerOptions": {
     "module": "NodeNext",
     "preserveValueImports": false,
+    "target": "ESNext", //최신 ES버전으로 트랜스파일
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "strict": true,
-    "noEmit": true,
+    "noEmit": true, //js 파일 생성하지 않게 설정(타입 체크용)
     "isolatedModules": true,
     "moduleResolution": "NodeNext",
     "allowImportingTsExtensions": true


### PR DESCRIPTION
- ts파일이 js파일로 트랜스파일시 생겼던 문제였음
- 트랜스파일시 최신 ES버전으로 변환되게 설정

## 📌 관련 이슈
- 에러 스택이 정상적으로 출력되지 않았음
```
Error: Not found
    at SqlTemplate.<anonymous> (file:///C:/Users/yongHwan/Desktop/project/tamagotchi/backend/src/db/template/SqlTemplate.ts:62:35)
    at step (file:///C:/Users/yongHwan/Desktop/project/tamagotchi/backend/src/db/template/SqlTemplate.ts:32:23)
    at Object.next (file:///C:/Users/yongHwan/Desktop/project/tamagotchi/backend/src/db/template/SqlTemplate.ts:13:53)    
    at fulfilled (file:///C:/Users/yongHwan/Desktop/project/tamagotchi/backend/src/db/template/SqlTemplate.ts:4:58)       
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
```
## ✨ 상세 내용
- 원인은 ts파일이 js로 변환될때 생겼던 문제
- 트랜스파일시 최신 ES버전으로 변환되게 하여 ts 코드와 동일하게 만듬
```
Error: Not found
    at SqlTemplate.getQuery (file:///C:/Users/yongHwan/Desktop/project/tamagotchi/backend/src/db/template/SqlTemplate.ts:10:23)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async UserService.getUser (file:///C:/Users/yongHwan/Desktop/project/tamagotchi/backend/src/service/UserService.ts:23:24)
    at async login (file:///C:/Users/yongHwan/Desktop/project/tamagotchi/backend/src/controllers/userController.ts:18:16)
```

관련 블로깅
https://nyh98.tistory.com/93
## 📸 스크린샷(선택)
